### PR TITLE
Bump Packer to 1.7.9 & variables isolation for os arch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - 'feature*'
-      - 'feature/*'
       - 'feature_*'
-      - 'hotfix*'
+      - 'feature/*'
       - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 22 * * *'
@@ -21,12 +21,12 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.packer'
         fetch-depth: 0
@@ -34,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.packer'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -44,23 +45,23 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
-      max-parallel: 8
+      max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.packer'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -69,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.packer'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,19 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.packer'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.packer'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 packer_app: packer
-packer_version: 1.7.8
+packer_version: 1.7.9
 packer_osarch: linux_amd64
 packer_dl_url: https://releases.hashicorp.com
 packer_dl_loc: /tmp
@@ -28,7 +28,7 @@ packer_bin_path: /usr/local/bin
 Variable        | Value (default)                  | Description
 --------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
 packer_app      | packer                           | Defines the app to install i.e. **packer**
-packer_version  | 1.7.8                            | Defined to dynamically fetch the desired version to install. Defaults to: **1.7.8**
+packer_version  | 1.7.9                            | Defined to dynamically fetch the desired version to install. Defaults to: **1.7.9**
 packer_osarch   | linux_amd64                      | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux_amd64**
 packer_dl_url   | <https://releases.hashicorp.com> | Defines URL to download the packer binary from.
 packer_dl_loc   | /tmp                             | Defined to dynamically set where to place the binary archive for `packer` temporarily. Defaults to: **/tmp**

--- a/README.md
+++ b/README.md
@@ -17,22 +17,30 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 packer_app: packer
 packer_version: 1.7.9
-packer_osarch: linux_amd64
+packer_os: linux
+packer_arch: amd64
 packer_dl_url: https://releases.hashicorp.com
 packer_dl_loc: /tmp
 packer_bin_path: /usr/local/bin
+packer_file_owner: root
+packer_file_group: root
+packer_file_mode: '0755'
 ```
 
 ### Variables table:
 
-Variable        | Value (default)                  | Description
---------------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
-packer_app      | packer                           | Defines the app to install i.e. **packer**
-packer_version  | 1.7.9                            | Defined to dynamically fetch the desired version to install. Defaults to: **1.7.9**
-packer_osarch   | linux_amd64                      | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux_amd64**
-packer_dl_url   | <https://releases.hashicorp.com> | Defines URL to download the packer binary from.
-packer_dl_loc   | /tmp                             | Defined to dynamically set where to place the binary archive for `packer` temporarily. Defaults to: **/tmp**
-packer_bin_path | /usr/local/bin                   | Defined to dynamically set the appropriate path to store packer binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+Variable          | Description
+----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------
+packer_app        | Defines the app to install i.e. **packer**
+packer_version    | Defined to dynamically fetch the desired version to install. Defaults to: **1.7.9**
+packer_os         | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
+packer_arch       | Defines os architecture. Used to set the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
+packer_dl_url     | Defines URL to download the packer binary from.
+packer_dl_loc     | Defined to dynamically set where to place the binary archive for `packer` temporarily. Defaults to: **/tmp**
+packer_bin_path   | Defined to dynamically set the appropriate path to store packer binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+packer_file_owner | Owner for the binary file of packer.
+packer_file_group | Group for the binary file of packer.
+packer_file_mode  | Mode for the binary file of packer.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for packer
 
 packer_app: packer
-packer_version: 1.7.8
+packer_version: 1.7.9
 packer_os: linux
 packer_arch: amd64
 packer_dl_url: https://releases.hashicorp.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,11 @@
 
 packer_app: packer
 packer_version: 1.7.8
-packer_osarch: linux_amd64
+packer_os: linux
+packer_arch: amd64
 packer_dl_url: https://releases.hashicorp.com
 packer_dl_loc: /tmp
 packer_bin_path: /usr/local/bin
+packer_file_owner: root
+packer_file_group: root
+packer_file_mode: '0755'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+  - name: ${DISTRO:-ubuntu-20.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=ansible-role-packer
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-packer
 sonar.coverage.exclusions=**/**
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -3,18 +3,8 @@
 
 - name: Debian/Ubuntu Family | Downloading archive for {{ packer_app }} {{ packer_version }} temporarily to {{ packer_dl_loc }}
   get_url:
-    url: "{{ packer_dl_url }}/{{ packer_app }}/{{ packer_version }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    url: "{{ packer_dl_url }}/{{ packer_app }}/{{ packer_version }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     dest: "{{ packer_dl_loc }}"
-
-# - name: Install python3-apt on Debian based systems, required for package_facts.
-#   apt:
-#     name: python3-apt
-#     state: present
-#     force_apt_get: yes
-#     update_cache: yes
-# - name: Gather package facts to verify if unzip is installed
-#   package_facts:
-#     manager: apt
 
 - name: Debian/Ubuntu Family | Install unzip if it is currently not in installed state
   apt:
@@ -22,23 +12,17 @@
     state: present
     force_apt_get: yes
     update_cache: yes
-    # when: packages['unzip'] is not defined
 
-- name: Debian/Ubuntu Family | Unarchive {{ packer_app }}
+- name: Debian/Ubuntu Family | Unarchive {{ packer_app }} {{ packer_version }}
   unarchive:
-    src: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    src: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     dest: "{{ packer_bin_path }}"
+    owner: "{{ packer_file_owner }}"
+    group: "{{ packer_file_group }}"
+    mode: "{{ packer_file_mode }}"
     remote_src: true
-
-# - name: Uninstalling unzip as it was originally not in installed state
-#   apt:
-#     name: unzip
-#     state: absent
-#     force_apt_get: yes
-#     update_cache: yes
-#   when: packages['unzip'] is not defined
 
 - name: Debian/Ubuntu Family | Remove {{ packer_app }} archive file
   file:
-    path: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    path: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     state: absent

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -3,33 +3,26 @@
 
 - name: EL Family | Downloading archive for {{ packer_app }} {{ packer_version }} temporarily to {{ packer_dl_loc }}
   get_url:
-    url: "{{ packer_dl_url }}/{{ packer_app }}/{{ packer_version }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    url: "{{ packer_dl_url }}/{{ packer_app }}/{{ packer_version }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     dest: "{{ packer_dl_loc }}"
 
-# - name: Gather package facts to verify if unzip is installed on EL based systems
-#   package_facts:
-#     manager: rpm
 
 - name: EL Family | Install unzip if it is currently not in installed state
   yum:
     name: unzip
     state: present
     update_cache: yes
-    # when: packages['unzip'] is not defined
 
-- name: EL Family | {{ packer_app }}_unarchive
+- name: EL Family | Unarchive {{ packer_app }} {{ packer_version }}
   unarchive:
-    src: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    src: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     dest: "{{ packer_bin_path }}"
+    owner: "{{ packer_file_owner }}"
+    group: "{{ packer_file_group }}"
+    mode: "{{ packer_file_mode }}"
     remote_src: true
-
-# - name: Uninstalling unzip from Debian based systems as it was originally not in installed state
-#   yum:
-#     name: unzip
-#     state: absent
-#   when: packages['unzip'] is not defined
 
 - name: EL Family | Remove {{ packer_app }} archive
   file:
-    path: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_osarch }}.zip"
+    path: "{{ packer_dl_loc }}/{{ packer_app }}_{{ packer_version }}_{{ packer_os }}_{{ packer_arch }}.zip"
     state: absent


### PR DESCRIPTION
- Utilize github actions/checkout@v2 and Python 3.10.0 in build-and-test workflow
- Utilize github actions/checkout@v2 and Python 3.10.0 in release workflow
- Separate out variables for OS and Arch
- Set owner and group for `packer` file.
- Bump `packer` to 1.7.9